### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/axiomtradeapi/helpers/trending_tokens.py
+++ b/axiomtradeapi/helpers/trending_tokens.py
@@ -353,7 +353,7 @@ if __name__ == '__main__':
             credentials = login_step2(otp_jwt_token, otp_code, email, b64_password)
             
             print('Login successful!')
-            print(f"Client Secret: {credentials.get('clientSecret')}")
+            print("Client Secret: [REDACTED]")
             print(f"Org ID: {credentials.get('orgId')}")
             print(f"User ID: {credentials.get('userId')}")
             


### PR DESCRIPTION
Potential fix for [https://github.com/ChipaDevTeam/AxiomTradeAPI-py/security/code-scanning/2](https://github.com/ChipaDevTeam/AxiomTradeAPI-py/security/code-scanning/2)

To fix this safely without changing core behavior, stop printing the raw secret and replace it with a redacted/metadata-only message. Keep the success flow and other non-sensitive informational prints unchanged.

Best single change in `axiomtradeapi/helpers/trending_tokens.py` is:
- Replace line printing `Client Secret` value with a safe message that confirms presence only (or prints masked length/prefix).
- Do not log `credentials.get('clientSecret')` directly anywhere.

In the shown snippet region (around lines 355–358), change:
- `print(f"Client Secret: {credentials.get('clientSecret')}")`
to
- `print("Client Secret: [REDACTED]")`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive credentials are now redacted in console output during authentication flows to prevent accidental exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->